### PR TITLE
fix: set explicit return type for Lyrics#search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # Extractors
+
 Extractors for `discord-player`.
 
 # Example
 
 ```js
-const { Reverbnation } = require("@discord-player/extractor");
+const { Reverbnation } = require('@discord-player/extractor');
 const player = new Player(client);
 
 // enables reverbnation player
-player.use("reverbnation", Reverbnation);
+player.use('reverbnation', Reverbnation);
 ```
 
 # Lyrics
-```js
-const { Lyrics } = require("@discord-player/extractor");
-const lyricsClient = Lyrics.init("api_key_or_leave_it_blank");
 
-lyricsClient.search("alan walker faded")
-    .then(x => console.log(x))
-    .catch(console.error);
+```js
+const { Lyrics } = require('@discord-player/extractor');
+const lyricsClient = Lyrics.init('api_key_or_leave_it_blank');
+
+lyricsClient
+    .search('alan walker faded')
+    // This will return `null` if no results are found.
+    .then((x) => console.log(x))
 ```
 
 ## Response

--- a/src/ext/Lyrics.ts
+++ b/src/ext/Lyrics.ts
@@ -9,7 +9,7 @@ export function init(apiKey?: string, force?: boolean) {
     return { search, client };
 }
 
-function search(query: string) {
+function search(query: string): Promise<LyricsData | null> {
     return new Promise<LyricsData>((resolve, reject) => {
         if (typeof query !== 'string')
             return reject(new TypeError(`Expected search query to be a string, received "${typeof query}"!`));


### PR DESCRIPTION
## This PR includes

- Set explicit return type. This was added because the `search` function can return null. 